### PR TITLE
Adds support for ebook-convert

### DIFF
--- a/etc/elibsrv.conf
+++ b/etc/elibsrv.conf
@@ -38,6 +38,12 @@ thumbdir =
 ; Note that when using this, a MOBI version of your ebooks will be
 ; automatically created for each of the ePub file you download as a MOBI file.
 kindlegenbin =
+; a sane default is "/usr/bin/kindlegen -locale en"
+
+
+; ebookconvert plugin. Similar to the kindlegen plugin, you can use ebookconvert
+; from calibre to convert epub to moby on the file.
+ebookconvertbin = 
 
 ; elibsrv uses pagination whenever a list of results is shown. This is
 ; necessary to avoid crashing/freezing client devices that aren't able to

--- a/etc/elibsrv.conf
+++ b/etc/elibsrv.conf
@@ -30,15 +30,21 @@ latestdays = 60
 ; performance reasons.
 thumbdir =
 
-; kindlegen plugin. If you'd like elibsrv to be able to serve *.mobi files to
+; convert plugin. If you'd like elibsrv to be able to serve *.mobi files to
 ; your kindle device, based on an automatic conversion of your ePub ebooks,
 ; then you will need to get the 'kindlegen' program for your OS (as provided
 ; by Amazon/Kindle), and set up the full path to the kindlegen binary below.
 ; The binary declared here MUST be executable by your web server daemon.
 ; Note that when using this, a MOBI version of your ebooks will be
 ; automatically created for each of the ePub file you download as a MOBI file.
-kindlegenbin =
-; a sane default is "/usr/bin/kindlegen -locale en"
+; you can use your favorite program for the conversion. The below example uses
+; kindlegen (by Amazon) and falls back to calibre's ebook-convert if that fails
+; ebook-convert is slower, so it prefers kindlegen by default, but you can 
+;use another program if you wish using %epub% and %mobi% as placeholders
+convertbin = "/usr/bin/kindlegen -locale en %epub% || /usr/bin/ebook-convert %epub% %mobi%"
+convert = 
+; convert = yes
+; enable this to start using the convert plugin
 
 
 ; ebookconvert plugin. Similar to the kindlegen plugin, you can use ebookconvert

--- a/frontend/index.php
+++ b/frontend/index.php
@@ -221,7 +221,7 @@ function normalizefilename($f) {
 }
 
 
-function printaqentry($outformat, $title, $crc32, $author, $language, $description, $publisher, $pubdate, $catdate, $moddate, $prettyurls, $filesize, $filename, $format, $kindlegenbin) {
+function printaqentry($outformat, $title, $crc32, $author, $language, $description, $publisher, $pubdate, $catdate, $moddate, $prettyurls, $filesize, $filename, $format, $convert) {
   // prepare the array with metadata
   $meta = array();
   $meta['title'] = $title;
@@ -243,7 +243,7 @@ function printaqentry($outformat, $title, $crc32, $author, $language, $descripti
     $meta['aqlink'] = $_SERVER['PHP_SELF'] . "?action=getfile&amp;query=" . $crc32;
     $meta['aqlinkmobi'] = $_SERVER['PHP_SELF'] . "?action=getmobi&amp;query=" . $crc32;
   }
-  if ((empty($kindlegenbin)) || ($format != 'epub')) $meta['aqlinkmobi'] = NULL; // drop the mobi link if no kindlegenbin path is configured, or source file is not epub
+  if ((empty($convert)) || ($format != 'epub')) $meta['aqlinkmobi'] = NULL; // drop the mobi link if conversion plugin is not enabled
   $meta['coverlink'] = $_SERVER['PHP_SELF'] . "?action=getcover&amp;query={$crc32}";
   $meta['thumblink'] = $_SERVER['PHP_SELF'] . "?action=getthumb&amp;query={$crc32}";
 
@@ -285,7 +285,7 @@ function mainindex($outformat, $title) {
 }
 
 
-function titlesindex($outformat, $db, $authorfilter, $langfilter, $tagfilter, $randcount, $latest, $search, $prettyurls, $kindlegenbin, $pagesize, $pagenum, $action) {
+function titlesindex($outformat, $db, $authorfilter, $langfilter, $tagfilter, $randcount, $latest, $search, $prettyurls, $convert, $pagesize, $pagenum, $action) {
   $fieldslist = 'crc32, title, author, description, language, publisher, pubdate, modtime, moddate, file, filesize, format';
   printheaders($outformat, "titlesindex", "Titles");
 
@@ -357,7 +357,7 @@ function titlesindex($outformat, $db, $authorfilter, $langfilter, $tagfilter, $r
     $filesize = $myrow['filesize'];
     $filename = $myrow['file'];
     $format = sqlformat2human($myrow['format']);
-    printaqentry($outformat, $title, $crc32, $author, $language, $description, $publisher, $pubdate, $catdate, $moddate, $prettyurls, $filesize, $filename, $format, $kindlegenbin);
+    printaqentry($outformat, $title, $crc32, $author, $language, $description, $publisher, $pubdate, $catdate, $moddate, $prettyurls, $filesize, $filename, $format, $convert);
   }
 
   printtrailer($outformat);
@@ -478,8 +478,7 @@ if (empty($thumbheight) || $thumbheight < 1) $thumbheight = 160;
 $title = getconf($params, 'title');
 if (empty($title)) $title = "Main menu";
 $thumbdir = getconf($params, 'thumbdir');
-$kindlegenbin = getconf($params, 'kindlegenbin');
-$ebookconvertbin = getconf($params, 'ebookconvertbin');
+$convert = getconf($params, 'convert');
 $pagesize = getconf($params, 'pagesize');
 if (empty($pagesize) || ($pagesize < 1)) $pagesize = 10;
 $randcount = getconf($params, 'randcount');
@@ -537,21 +536,24 @@ if ($action == "getfile") {
     readfile($localfile['filename']);
   }
 } else if ($action == "getmobi") {
-  if (empty($kindlegenbin) and empty($ebookconvertbin)) {
+  if (empty($convert)) {
     header('content-type: text/html');
-    echo "<html><head></head><body>mobi conversion not available, because kindlegenbin not set.</body></html>\n";
+    echo "<html><head></head><body>mobi conversion not available, because convert plugin is disabled not set.</body></html>\n";
   } else {
     $localfile = getLocalFilename($db, $query);
     if ($localfile != NULL) {
       // build the filename of the mobi file
       $localfilemobi = pathinfo($localfile['filename'], PATHINFO_DIRNAME) . '/' . pathinfo($localfile['filename'], PATHINFO_FILENAME) . '.mobi';
-      // if doesn't exist yet, convert it using the kindlegen/ebook-convert binary
-      if (empty($ebookconvertbin)) {
-        $cmd = $kindlegenbin . ' ' . escapeshellarg($localfile['filename']);
-      }
-      else {
-        $cmd = $ebookconvertbin . ' ' . escapeshellarg($localfile['filename']) . ' ' . $localfilemobi;
-      }
+      
+      // if doesn't exist yet, convert it using convertbin
+      $cmd = getconf($params,'convertbin');
+
+      $search_replace = [
+        '%epub%'  =>  escapeshellarg($localfile['filename']),
+        '%mobi%'  =>  escapeshellarg($localfilemobi),
+      ];
+
+      $cmd = str_replace(array_keys($search_replace), array_values($search_replace), $cmd);
 
       if (! file_exists($localfilemobi)) {
         $execres = exec($cmd);
@@ -560,7 +562,7 @@ if ($action == "getfile") {
       // if file still doesn't exist, then something went wrong
       if (! file_exists($localfilemobi)) {
         header('content-type: text/html');
-        echo "<html><head></head><body>ERROR: mobi conversion failed. please check your kindlegenbin/ebook-convert setting.<br>{$cmd}<br><br><pre>{$execres}</pre></body></html>\n";
+        echo "<html><head></head><body>ERROR: mobi conversion failed. please check your convert setting.<br>{$cmd}<br><br><pre>{$execres}</pre></body></html>\n";
       } else {
         // finally, return the mobi file
         header('content-type: application/x-mobipocket-ebook');
@@ -596,9 +598,9 @@ if ($action == "getfile") {
   header("content-type: " . image_type_to_mime_type(exif_imagetype($coverinzip)));
   readfile($coverinzip);
 } else if ($action == "titles") {
-  titlesindex($outformat, $db, $authorfilter, $langfilter, $tagfilter, 0, 0, $query, $prettyurls, $kindlegenbin, $pagesize, $pagenum, $action);
+  titlesindex($outformat, $db, $authorfilter, $langfilter, $tagfilter, 0, 0, $query, $prettyurls, $convert, $pagesize, $pagenum, $action);
 } else if ($action == "latest") {
-  titlesindex($outformat, $db, NULL, NULL, NULL, 0, $latestdays, NULL, $prettyurls, $kindlegenbin, $pagesize, $pagenum, $action);
+  titlesindex($outformat, $db, NULL, NULL, NULL, 0, $latestdays, NULL, $prettyurls, $convert, $pagesize, $pagenum, $action);
 } else if ($action == "authors") {
   authorsindex($outformat, $db);
 } else if ($action == "authorsl") {
@@ -608,7 +610,7 @@ if ($action == "getfile") {
 } else if ($action == "tags") {
   tagsindex($outformat, $db);
 } else if ($action == "rand") {
-  titlesindex($outformat, $db, NULL, NULL, NULL, $randcount, 0, NULL, $prettyurls, $kindlegenbin, $pagesize, $pagenum, $action);
+  titlesindex($outformat, $db, NULL, NULL, NULL, $randcount, 0, NULL, $prettyurls, $convert, $pagesize, $pagenum, $action);
 } else if ($action == "searchform") {
   searchform($outformat);
 } else {


### PR DESCRIPTION
I noticed that it broke on certain EPUBs (kindlegen doesn't seem to be able to handle EPUBv3). 

As a workaround, I patched elibsrv to support "converters" instead of just kindlegen. So the config section says:

    convertbin = "/usr/bin/kindlegen -locale en %epub% || /usr/bin/ebook-convert %epub% %mobi%"

Where %epub% and %mobi% get replaced with the correct complete filenames.

This makes sure that the faster kindlegen runs first, and the slower ebook-convert (which forces me to install calibre) only runs if kindlegen fails.